### PR TITLE
Fix Scan Number

### DIFF
--- a/src/components/tabulator/TabulatorTagTable.vue
+++ b/src/components/tabulator/TabulatorTagTable.vue
@@ -101,10 +101,6 @@ export default defineComponent({
         return
       }
       
-      const scan = row['Scan']
-      if (typeof scan === 'number') {
-        this.selectionStore.updateSelectedScan(scan)
-      }
       const mzs = row['mzs']
       let masses : number[] = []
       if (typeof mzs === 'string') {


### PR DESCRIPTION
This PR reenables the scan number set by the protein table. Previously it was overwritten when entries in the tag table are selected.