### PR TITLE
Fix amino acid selection highlighting in tag visualization

### DIFF
--- a/src/components/plotly/lineplot/PlotlyLineplotTagger.vue
+++ b/src/components/plotly/lineplot/PlotlyLineplotTagger.vue
@@ -201,6 +201,17 @@ export default defineComponent({
       }
       return []
     },
+    // A tag's fragment masses arrive in descending order, so the rendered tag
+    // letters use a reversed index (sequence.length - 1 - i). Reverse the
+    // selected within-tag index into that same space so the highlight lands on
+    // the residue the user selected instead of its mirror position.
+    reversedSelectedAA(): number | undefined {
+      const tag = this.selectionStore.selectedTag
+      if (tag === undefined) {
+        return undefined
+      }
+      return (tag.sequence.length - 1) - tag.selectedAA
+    },
     highlightedValues(): highlightData[] {
 
       const positions = this.highlightedMassPos
@@ -246,8 +257,8 @@ export default defineComponent({
         const posHighlight = this.highlightedPos(x_val)
         if (
           (posHighlight !== undefined) &&
-          ((this.selectionStore.selectedTag?.selectedAA == posHighlight) || 
-          (this.selectionStore.selectedTag?.selectedAA == posHighlight-1))
+          ((this.reversedSelectedAA == posHighlight) ||
+          (this.reversedSelectedAA == posHighlight-1))
         ){
           selected_x.push(x_val)
           selected_y.push(y_val)
@@ -384,8 +395,8 @@ export default defineComponent({
         let fillcolor = '#E4572E'
         let family = 'sans-serif'
         if (
-          (this.selectionStore.selectedTag?.selectedAA == i) || 
-          (this.selectionStore.selectedTag?.selectedAA == i-1)) {
+          (this.reversedSelectedAA == i) ||
+          (this.reversedSelectedAA == i-1)) {
             fillcolor = "#F3A712"
             family = 'Arial Black, Arial Bold, Arial, sans-serif'
         }
@@ -439,7 +450,7 @@ export default defineComponent({
 
         let fillcolor = '#E4572E'
         let family = 'sans-serif'
-        if ((this.selectionStore.selectedTag?.selectedAA == i)) {
+        if ((this.reversedSelectedAA == i)) {
             fillcolor = "#F3A712"
             family = 'Arial Black, Arial Bold, Arial, sans-serif'
         }

--- a/src/components/plotly/lineplot/PlotlyLineplotUnified.vue
+++ b/src/components/plotly/lineplot/PlotlyLineplotUnified.vue
@@ -160,6 +160,18 @@ export default defineComponent({
     selectedAA(): number | undefined {
       return this.isTnTMode ? this.selectionStore.selectedTag?.selectedAA : undefined
     },
+
+    // A tag's fragment masses arrive in descending order, so the rendered tag
+    // letters use a reversed index (sequence.length - 1 - i). Reverse the
+    // selected within-tag index into that same space so the highlight lands on
+    // the residue the user selected instead of its mirror position.
+    reversedSelectedAA(): number | undefined {
+      const tag = this.selectionStore.selectedTag
+      if (tag === undefined) {
+        return undefined
+      }
+      return (tag.sequence.length - 1) - tag.selectedAA
+    },
     
     currentTitle(): string {
       return this.localTitle || this.args.title
@@ -514,8 +526,8 @@ export default defineComponent({
         
         if (
           (posHighlight) &&
-          ((this.selectionStore.selectedTag?.selectedAA == Math.floor(i / 3)) ||
-          (this.selectionStore.selectedTag?.selectedAA == Math.floor(i / 3) - 1))
+          ((this.reversedSelectedAA == Math.floor(i / 3)) ||
+          (this.reversedSelectedAA == Math.floor(i / 3) - 1))
         ){
           selected_x.push(x_val)
           selected_y.push(y_val)
@@ -897,7 +909,7 @@ export default defineComponent({
 
         // Mass Buttons + Sequence Arrows with overlap detection
         let arrowAnnotations: Partial<Plotly.Annotations>[] = []
-        const selectedAA = this.selectionStore.selectedTag?.selectedAA
+        const reversedSelectedAA = this.reversedSelectedAA
         const annotationBoxes = this.annotationBoxData
         const visibleMassBoxes = annotationBoxes.filter(box => box.type === 'mass' && box.visible)
         
@@ -916,7 +928,7 @@ export default defineComponent({
             let fillcolor = this.styling.annotationColors.massButton
             let family = 'sans-serif'
             
-            if ((selectedAA === i) || (selectedAA === i - 1)) {
+            if ((reversedSelectedAA === i) || (reversedSelectedAA === i - 1)) {
                 fillcolor = this.styling.annotationColors.selectedMassButton
                 family = 'Arial Black, Arial Bold, Arial, sans-serif'
             }
@@ -983,7 +995,7 @@ export default defineComponent({
             let fillcolor = this.styling.annotationColors.sequenceArrow
             let family = 'sans-serif'
             
-            if (selectedAA === i) {
+            if (reversedSelectedAA === i) {
                 fillcolor = this.styling.annotationColors.selectedSequenceArrow
                 family = 'Arial Black, Arial Bold, Arial, sans-serif'
             }


### PR DESCRIPTION
## Summary
Fixed incorrect highlighting of selected amino acids in tag visualizations by properly accounting for the reversed indexing used when rendering tag sequences.

## Problem
Tag fragment masses arrive in descending order, causing rendered tag letters to use a reversed index (sequence.length - 1 - i). However, the selection highlighting logic was using the original selectedAA index directly, causing highlights to appear on the mirror position of the actually selected residue instead of the correct one.

## Changes
- Added `reversedSelectedAA` computed property to both `PlotlyLineplotUnified.vue` and `PlotlyLineplotTagger.vue` that correctly transforms the selected amino acid index into the reversed index space
- Updated all selection highlighting comparisons to use `reversedSelectedAA` instead of directly accessing `selectionStore.selectedTag?.selectedAA`
- Applied fixes across multiple rendering contexts:
  - Mass button highlighting
  - Sequence arrow highlighting
  - General position highlighting logic

## Implementation Details
The `reversedSelectedAA` computed property calculates: `(tag.sequence.length - 1) - tag.selectedAA`, which mirrors the same transformation applied during rendering. This ensures the visual highlight aligns with the user's actual selection.

https://claude.ai/code/session_01W7sVJftJ7r4NpRnFaeMTAR