### PR TITLE
Add "best per spectrum" toggle to FLASHTnT Protein Table

### DIFF
--- a/src/components/tabulator/TabulatorProteinTable.vue
+++ b/src/components/tabulator/TabulatorProteinTable.vue
@@ -9,7 +9,17 @@
     :initial-sort="initialSort"
     :go-to-fields="['Scan', 'accession']"
     @row-selected="updateSelectedProtein"
-  />
+  >
+    <template #end-title-row>
+      <v-checkbox
+        v-model="bestPerSpectrumOnly"
+        label="Best per spectrum"
+        hide-details
+        density="compact"
+        color="primary"
+      />
+    </template>
+  </TabulatorTable>
 </template>
 
 <script lang="ts">
@@ -43,6 +53,9 @@ export default defineComponent({
   },
   data() {
     return {
+      // Show only the best (highest-Score) proteoform hit per spectrum by
+      // default; users can switch this off to see every hit.
+      bestPerSpectrumOnly: true,
       columnDefinitions: [
         { 
           title: 'Scan No.', field: 'Scan', sorter: 'number',  
@@ -106,11 +119,83 @@ export default defineComponent({
     },
     tableData(): Record<string, unknown>[] {
       const rows = this.streamlitDataStore.dataForDrawing.protein_table
-      rows.forEach((row) => (row['id'] = row['index']))
-      return rows
+      if (!rows) {
+        return []
+      }
+      // Map to fresh row objects (never mutate the store array) so every
+      // recompute yields a new reference -- this keeps the store's full list
+      // intact for selection lookups and reliably triggers the base table's
+      // `watch tableData -> drawTable` when the toggle flips.
+      const rowsWithId = rows.map((row) => ({ ...row, id: row['index'] }))
+      return this.bestPerSpectrumOnly
+        ? this.filterBestPerSpectrum(rowsWithId)
+        : rowsWithId
+    },
+  },
+  watch: {
+    // When the toggle changes and the currently selected proteoform is no
+    // longer visible (its hit was filtered out), reselect the surviving best
+    // hit of the same scan so the table highlight and the Python-synced side
+    // panels (sequence view, tag table, spectrum) stay consistent.
+    bestPerSpectrumOnly() {
+      this.$nextTick(() => {
+        const selected = this.selectionStore.selectedProteinIndex
+        if (selected === undefined) {
+          return
+        }
+        const stillVisible = this.tableData.some(
+          (row) => row['index'] === selected || row['id'] === selected
+        )
+        if (stillVisible) {
+          return
+        }
+        const current = this.streamlitDataStore.dataForDrawing.protein_table?.find(
+          (row) => row['index'] === selected || row['id'] === selected
+        )
+        const scan = current?.['Scan']
+        const replacement = this.tableData.find((row) => row['Scan'] === scan)
+        if (replacement === undefined) {
+          return
+        }
+        const replacementIndex = replacement['index']
+        if (typeof replacementIndex === 'number') {
+          this.updateSelectedProtein(replacementIndex)
+        }
+      })
     },
   },
   methods: {
+    /**
+     * Collapse the rows to the highest-Score proteoform hit per spectrum
+     * (Scan). Rows without a numeric Scan are passed through unchanged so they
+     * are never grouped together; ties keep the first-seen row.
+     */
+    filterBestPerSpectrum(
+      rows: Record<string, unknown>[]
+    ): Record<string, unknown>[] {
+      const bestByScan = new Map<number, Record<string, unknown>>()
+      const passthrough: Record<string, unknown>[] = []
+      for (const row of rows) {
+        const scan = row['Scan']
+        if (typeof scan !== 'number' || Number.isNaN(scan)) {
+          passthrough.push(row)
+          continue
+        }
+        const existing = bestByScan.get(scan)
+        if (
+          existing === undefined ||
+          this.toScore(row['Score']) > this.toScore(existing['Score'])
+        ) {
+          bestByScan.set(scan, row)
+        }
+      }
+      return [...bestByScan.values(), ...passthrough]
+    },
+    /** Coerce an unknown Score to a comparable number; NaN/missing -> -Infinity. */
+    toScore(value: unknown): number {
+      const n = typeof value === 'number' ? value : Number(value)
+      return Number.isNaN(n) ? Number.NEGATIVE_INFINITY : n
+    },
     updateSelectedProtein(selectedRow?: number) {
       if (selectedRow !== undefined) {
         this.selectionStore.updateSelectedProtein(selectedRow)


### PR DESCRIPTION
## What

Adds a **"Best per spectrum"** checkbox to the FLASHTnT **Protein Table** header. When enabled (the **default**), the table shows only the highest-`Score` proteoform hit per spectrum (`Scan`); unchecking it restores every hit.

## Why

A single MS2 spectrum often yields many candidate proteoform hits, so the table is dominated by lower-ranked duplicates of the same scan. Collapsing to the best hit per spectrum by default makes the results read as a clean per-spectrum summary, while power users can still see all hits.

## How

All client-side in `TabulatorProteinTable.vue`:
- `bestPerSpectrumOnly` data field, defaulting to `true`.
- `tableData` now maps to a **fresh array** each recompute (no store mutation; reliably triggers the base table's redraw) and, when the toggle is on, keeps the max-`Score` row per `Scan` (`filterBestPerSpectrum` + `toScore`, with defensive handling of non-numeric `Scan`/NaN scores).
- A `watch` reselects the surviving best hit of the same scan if the current selection gets filtered out, keeping the linked Sequence View / Tag Table / Combined Spectrum panels in sync.

No Python or backend changes; the selection store / cross-component linking are untouched.

## Notes

- This is the single relevant commit cherry-picked onto `FVdeploy` (no unrelated TIC commits).
- Development PRs: source `#23`; FLASHApp bundle/submodule `OpenMS/FLASHApp#79`.
- Verified: `vue-tsc` type-check + `vite build` pass; against the bundled antibody example (8 hits all on Scan 1) the table collapses 8 → 1 (top hit `SigmaMabH`, Score 206) and expands back to 8 when unchecked.

https://claude.ai/code/session_01JLThruR4Rg2dkWfnNWRQ6a

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLThruR4Rg2dkWfnNWRQ6a)_