### PR TITLE
Fix inverted tag residue highlight in TnT annotated spectrum

### DIFF
--- a/src/components/plotly/lineplot/PlotlyLineplotTagger.vue
+++ b/src/components/plotly/lineplot/PlotlyLineplotTagger.vue
@@ -201,6 +201,17 @@ export default defineComponent({
       }
       return []
     },
+    // A tag's fragment masses arrive in descending order, so the rendered tag
+    // letters use a reversed index (sequence.length - 1 - i). Reverse the
+    // selected within-tag index into that same space so the highlight lands on
+    // the residue the user selected instead of its mirror position.
+    reversedSelectedAA(): number | undefined {
+      const tag = this.selectionStore.selectedTag
+      if (tag === undefined) {
+        return undefined
+      }
+      return (tag.sequence.length - 1) - tag.selectedAA
+    },
     highlightedValues(): highlightData[] {
 
       const positions = this.highlightedMassPos
@@ -246,8 +257,8 @@ export default defineComponent({
         const posHighlight = this.highlightedPos(x_val)
         if (
           (posHighlight !== undefined) &&
-          ((this.selectionStore.selectedTag?.selectedAA == posHighlight) || 
-          (this.selectionStore.selectedTag?.selectedAA == posHighlight-1))
+          ((this.reversedSelectedAA == posHighlight) ||
+          (this.reversedSelectedAA == posHighlight-1))
         ){
           selected_x.push(x_val)
           selected_y.push(y_val)
@@ -384,8 +395,8 @@ export default defineComponent({
         let fillcolor = '#E4572E'
         let family = 'sans-serif'
         if (
-          (this.selectionStore.selectedTag?.selectedAA == i) || 
-          (this.selectionStore.selectedTag?.selectedAA == i-1)) {
+          (this.reversedSelectedAA == i) ||
+          (this.reversedSelectedAA == i-1)) {
             fillcolor = "#F3A712"
             family = 'Arial Black, Arial Bold, Arial, sans-serif'
         }
@@ -439,7 +450,7 @@ export default defineComponent({
 
         let fillcolor = '#E4572E'
         let family = 'sans-serif'
-        if ((this.selectionStore.selectedTag?.selectedAA == i)) {
+        if ((this.reversedSelectedAA == i)) {
             fillcolor = "#F3A712"
             family = 'Arial Black, Arial Bold, Arial, sans-serif'
         }

--- a/src/components/plotly/lineplot/PlotlyLineplotUnified.vue
+++ b/src/components/plotly/lineplot/PlotlyLineplotUnified.vue
@@ -160,6 +160,18 @@ export default defineComponent({
     selectedAA(): number | undefined {
       return this.isTnTMode ? this.selectionStore.selectedTag?.selectedAA : undefined
     },
+
+    // A tag's fragment masses arrive in descending order, so the rendered tag
+    // letters use a reversed index (sequence.length - 1 - i). Reverse the
+    // selected within-tag index into that same space so the highlight lands on
+    // the residue the user selected instead of its mirror position.
+    reversedSelectedAA(): number | undefined {
+      const tag = this.selectionStore.selectedTag
+      if (tag === undefined) {
+        return undefined
+      }
+      return (tag.sequence.length - 1) - tag.selectedAA
+    },
     
     currentTitle(): string {
       return this.localTitle || this.args.title
@@ -514,8 +526,8 @@ export default defineComponent({
         
         if (
           (posHighlight) &&
-          ((this.selectionStore.selectedTag?.selectedAA == Math.floor(i / 3)) ||
-          (this.selectionStore.selectedTag?.selectedAA == Math.floor(i / 3) - 1))
+          ((this.reversedSelectedAA == Math.floor(i / 3)) ||
+          (this.reversedSelectedAA == Math.floor(i / 3) - 1))
         ){
           selected_x.push(x_val)
           selected_y.push(y_val)
@@ -897,7 +909,7 @@ export default defineComponent({
 
         // Mass Buttons + Sequence Arrows with overlap detection
         let arrowAnnotations: Partial<Plotly.Annotations>[] = []
-        const selectedAA = this.selectionStore.selectedTag?.selectedAA
+        const reversedSelectedAA = this.reversedSelectedAA
         const annotationBoxes = this.annotationBoxData
         const visibleMassBoxes = annotationBoxes.filter(box => box.type === 'mass' && box.visible)
         
@@ -916,7 +928,7 @@ export default defineComponent({
             let fillcolor = this.styling.annotationColors.massButton
             let family = 'sans-serif'
             
-            if ((selectedAA === i) || (selectedAA === i - 1)) {
+            if ((reversedSelectedAA === i) || (reversedSelectedAA === i - 1)) {
                 fillcolor = this.styling.annotationColors.selectedMassButton
                 family = 'Arial Black, Arial Bold, Arial, sans-serif'
             }
@@ -983,7 +995,7 @@ export default defineComponent({
             let fillcolor = this.styling.annotationColors.sequenceArrow
             let family = 'sans-serif'
             
-            if (selectedAA === i) {
+            if (reversedSelectedAA === i) {
                 fillcolor = this.styling.annotationColors.selectedSequenceArrow
                 family = 'Arial Black, Arial Bold, Arial, sans-serif'
             }


### PR DESCRIPTION
## Problem
In the FLASHTnT viewer, selecting a residue in the sequence view highlighted the **mirror** position within each tag in the annotated spectrum — e.g. selecting `E19` highlighted `T` in tag `MTEF` and `L` in tag `LMTE`.

## Root cause
A tag's fragment masses are drawn in descending m/z order, so the rendered tag letters intentionally use a reversed index (`sequence.length - 1 - i`). The three highlight comparisons (peaks, mass buttons, sequence letters) still used the non-reversed index `i`, so the highlight landed on the mirror residue. The within-tag index (`selectedAA = selectedAApos - startPos`) itself was already correct — only the rendering was inconsistent.

## Fix
Add a `reversedSelectedAA` computed (`sequence.length - 1 - selectedAA`) and use it in all three highlight comparisons so they match the already-correct reversed letter display. Applied to `PlotlyLineplotUnified.vue` (the live component) and `PlotlyLineplotTagger.vue` (parity). The letter lookup itself is unchanged.

## Verification
- Highlight now lands on the selected residue: `E` is highlighted in both `MTEF` and `LMTE`.
- `vue-tsc` type-check passes.

## Note
This is a cherry-pick of the single fix commit onto `FVdeploy` (the branch the Docker image builds the component from), without the unrelated `develop` changes.

https://claude.ai/code/session_01W7sVJftJ7r4NpRnFaeMTAR

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7sVJftJ7r4NpRnFaeMTAR)_