### PR TITLE
Clear selected amino acid on tag deselection

### DIFF
--- a/src/components/tabulator/TabulatorProteinTable.vue
+++ b/src/components/tabulator/TabulatorProteinTable.vue
@@ -234,6 +234,7 @@ export default defineComponent({
         }
         this.selectionStore.updateSelectedTag(undefined)
         this.selectionStore.updateTagData(undefined)
+        this.selectionStore.updateSelectedAA(undefined)
       }
     },
   },


### PR DESCRIPTION
## Summary
Added cleanup logic to clear the selected amino acid state when a tag is deselected in the protein table component.

## Key Changes
- Added `this.selectionStore.updateSelectedAA(undefined)` call in the tag deselection handler to ensure the selected amino acid state is properly reset alongside tag and tag data

## Implementation Details
This change ensures consistent state management by clearing all related selection data when a user deselects a tag. Previously, only the tag and tag data were being cleared, which could leave the selected amino acid in an inconsistent state.

https://claude.ai/code/session_01Ru4C8Nx5KuvMFJ77rPLAGw