### PR TITLE
Fix selection state synchronization with Python backend

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -35,7 +35,18 @@ export default defineComponent({
     watch(
       selectionStore.$state,
       (newState) => {
-        Streamlit.setComponentValue(toRaw(newState))
+        // Streamlit serializes the component value as JSON, which silently drops
+        // keys whose value is `undefined`. A *cleared* selection (set back to
+        // undefined) would therefore never reach Python, so the StateTracker keeps
+        // echoing the stale value and the clear is lost (e.g. deselecting an amino
+        // acid, or switching proteoform). Send `null` for undefined fields so the
+        // cleared value round-trips; streamlit-data converts it back to undefined.
+        const raw = toRaw(newState) as unknown as Record<string, unknown>
+        const payload: Record<string, unknown> = {}
+        for (const key in raw) {
+          payload[key] = raw[key] === undefined ? null : raw[key]
+        }
+        Streamlit.setComponentValue(payload)
       },
       { deep: true, immediate: true }
     )

--- a/src/components/tabulator/TabulatorProteinTable.vue
+++ b/src/components/tabulator/TabulatorProteinTable.vue
@@ -197,44 +197,36 @@ export default defineComponent({
       return Number.isNaN(n) ? Number.NEGATIVE_INFINITY : n
     },
     updateSelectedProtein(selectedRow?: number) {
-      if (selectedRow !== undefined) {
-        this.selectionStore.updateSelectedProtein(selectedRow)
-        
-        // Add diagnostic logging for debugging
-        const proteinTable = this.streamlitDataStore.dataForDrawing.protein_table
-        console.log('[DEBUG] updateSelectedProtein called:')
-        console.log('  selectedRow (from getIndex()):', selectedRow)
-        console.log('  protein_table length:', proteinTable?.length)
-        
-        // Validate protein table exists
-        if (!proteinTable || !Array.isArray(proteinTable) || proteinTable.length === 0) {
-          console.error('[ERROR] protein_table is not available or empty')
-          return
-        }
-        
-        // FIX: Find protein by index field instead of using selectedRow as array index
-        // selectedRow is actually the ProteoformIndex (ID), not array position
-        const selectedProtein = proteinTable.find(protein =>
-          protein && (protein.index === selectedRow || protein.id === selectedRow)
-        )
-        
-        if (!selectedProtein) {
-          console.error('[ERROR] Could not find protein with index/id:', selectedRow)
-          console.error('  Available protein indices:', proteinTable.map(p => p?.index || p?.id).slice(0, 10))
-          return
-        }
-        
-        console.log('  Found protein:', selectedProtein)
-        const scan_number = selectedProtein['Scan']
-        console.log('  scan_number found:', scan_number)
-        
-        if ((scan_number !== undefined) && (typeof scan_number == 'number')) {
-          const scan_id = this.streamlitDataStore.allDataForDrawing.per_scan_data.findIndex((data) => data['Scan'] === scan_number)
-          this.selectionStore.updateSelectedScan(scan_id)
-        }
-        this.selectionStore.updateSelectedTag(undefined)
-        this.selectionStore.updateTagData(undefined)
-        this.selectionStore.updateSelectedAA(undefined)
+      if (selectedRow === undefined) {
+        return
+      }
+      this.selectionStore.updateSelectedProtein(selectedRow)
+
+      // Clear residue/tag selection up front so switching proteoform always
+      // resets them -- even if the scan lookup below bails out early. (These
+      // clears propagate to the other components via the null-bridge in App.vue.)
+      this.selectionStore.updateSelectedTag(undefined)
+      this.selectionStore.updateTagData(undefined)
+      this.selectionStore.updateSelectedAA(undefined)
+
+      const proteinTable = this.streamlitDataStore.dataForDrawing.protein_table
+      if (!proteinTable || !Array.isArray(proteinTable) || proteinTable.length === 0) {
+        return
+      }
+
+      // selectedRow is the ProteoformIndex (ID), not the array position, so look
+      // the proteoform up by its index/id field rather than indexing directly.
+      const selectedProtein = proteinTable.find(protein =>
+        protein && (protein.index === selectedRow || protein.id === selectedRow)
+      )
+      if (!selectedProtein) {
+        return
+      }
+
+      const scan_number = selectedProtein['Scan']
+      if ((scan_number !== undefined) && (typeof scan_number == 'number')) {
+        const scan_id = this.streamlitDataStore.allDataForDrawing.per_scan_data.findIndex((data) => data['Scan'] === scan_number)
+        this.selectionStore.updateSelectedScan(scan_id)
       }
     },
   },

--- a/src/stores/streamlit-data.ts
+++ b/src/stores/streamlit-data.ts
@@ -33,14 +33,20 @@ export const useStreamlitDataStore = defineStore('streamlit-data', {
     updateRenderData(newData: RenderData) {
       const selectionStore = useSelectionStore()
       selectionStore.$patch(state => {
-        if (newData.args.selection_store.id !== state.id) {
-        for (const key in state) {
-          (state as any)[key] = undefined
+        const incoming = newData.args.selection_store as Record<string, unknown>
+        if (incoming.id !== state.id) {
+          for (const key in state) {
+            (state as any)[key] = undefined
+          }
         }
-      }
-        Object.assign(state, newData.args.selection_store)
+        // Python echoes cleared selections as `null` (App.vue sends null for
+        // undefined so the clear survives JSON round-tripping). Convert back to
+        // `undefined` so the rest of the app keeps its `=== undefined` semantics
+        // and cleared fields overwrite stale local values in every iframe.
+        for (const key in incoming) {
+          (state as any)[key] = incoming[key] === null ? undefined : incoming[key]
+        }
       })
-      console.log(newData.args.selection_store.id)
 
       if (this.hash === newData.args.hash) {
         return


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where cleared selections (set to `undefined`) were not being properly synchronized with the Python backend. The problem occurred because JSON serialization silently drops `undefined` values, causing stale selections to persist when users deselected items or switched proteoforms.

## Key Changes

- **App.vue**: Modified the state watcher to convert `undefined` values to `null` before sending to Streamlit, ensuring cleared selections survive JSON serialization and reach Python
- **streamlit-data.ts**: Updated `updateRenderData()` to convert `null` values back to `undefined` when receiving state from Python, maintaining the app's `=== undefined` semantics and ensuring cleared fields overwrite stale local values
- **TabulatorProteinTable.vue**: Refactored `updateSelectedProtein()` to:
  - Clear residue/tag selections upfront so switching proteoforms always resets them, even if scan lookup fails
  - Removed extensive debug logging and error messages
  - Simplified control flow with early returns for better readability
  - Preserved the fix for looking up proteoforms by index/id field rather than array position

## Implementation Details

The fix implements a bidirectional null-bridge pattern:
- Vue → Python: `undefined` → `null` (survives JSON serialization)
- Python → Vue: `null` → `undefined` (maintains app semantics)

This ensures that cleared selections properly round-trip through the JSON serialization boundary and that the StateTracker in Python receives the cleared state, preventing it from echoing stale values back to the UI.

https://claude.ai/code/session_01TWkpASnLwnhMAQRxuYFpNs